### PR TITLE
MSM Refactor

### DIFF
--- a/rtcm3/antenna.go
+++ b/rtcm3/antenna.go
@@ -21,8 +21,8 @@ type AntennaReferencePoint struct {
 	ReferencePointZ           int64
 }
 
-func (arp AntennaReferencePoint) Number() uint16 {
-	return arp.MessageNumber
+func (arp AntennaReferencePoint) Number() int {
+	return int(arp.MessageNumber)
 }
 
 func SerializeAntennaReferencePoint(arp AntennaReferencePoint) []byte {
@@ -107,8 +107,8 @@ type MessageAntennaDescriptor struct {
 	AntennaSetupId     uint8
 }
 
-func (ad MessageAntennaDescriptor) Number() uint16 {
-	return ad.MessageNumber
+func (ad MessageAntennaDescriptor) Number() int {
+	return int(ad.MessageNumber)
 }
 
 func DeserializeAntennaDescriptor(r *iobit.Reader) (desc MessageAntennaDescriptor) {
@@ -178,8 +178,8 @@ type Message1033 struct {
 	ReceiverSerialNumber    string
 }
 
-func (msg Message1033) Number() uint16 {
-	return msg.MessageNumber
+func (msg Message1033) Number() int {
+	return int(msg.MessageNumber)
 }
 
 func DeserializeMessage1033(data []byte) (msg Message1033) {

--- a/rtcm3/data/1071_obj.go
+++ b/rtcm3/data/1071_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1071 = rtcm3.Message1071{
 	MessageMsm1: rtcm3.MessageMsm1{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x42f,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x1a6055a8,

--- a/rtcm3/data/1072_obj.go
+++ b/rtcm3/data/1072_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1072 = rtcm3.Message1072{
 	MessageMsm2: rtcm3.MessageMsm2{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x430,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x1a6055a8,

--- a/rtcm3/data/1073_obj.go
+++ b/rtcm3/data/1073_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1073 = rtcm3.Message1073{
 	MessageMsm3: rtcm3.MessageMsm3{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x431,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x1a6055a8,

--- a/rtcm3/data/1074_obj.go
+++ b/rtcm3/data/1074_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1074 = rtcm3.Message1074{
 	MessageMsm4: rtcm3.MessageMsm4{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x432,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x1a6055a8,

--- a/rtcm3/data/1075_obj.go
+++ b/rtcm3/data/1075_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1075 = rtcm3.Message1075{
 	MessageMsm5: rtcm3.MessageMsm5{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x433,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x1a6055a8,

--- a/rtcm3/data/1076_obj.go
+++ b/rtcm3/data/1076_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1076 = rtcm3.Message1076{
 	MessageMsm6: rtcm3.MessageMsm6{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x434,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x1a6055a8,

--- a/rtcm3/data/1077_obj.go
+++ b/rtcm3/data/1077_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1077 = rtcm3.Message1077{
 	MessageMsm7: rtcm3.MessageMsm7{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x435,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x1a6055a8,

--- a/rtcm3/data/1081_obj.go
+++ b/rtcm3/data/1081_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1081 = rtcm3.Message1081{
 	MessageMsm1: rtcm3.MessageMsm1{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x439,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x29450ed8,

--- a/rtcm3/data/1082_obj.go
+++ b/rtcm3/data/1082_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1082 = rtcm3.Message1082{
 	MessageMsm2: rtcm3.MessageMsm2{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x43a,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x29450ed8,

--- a/rtcm3/data/1083_obj.go
+++ b/rtcm3/data/1083_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1083 = rtcm3.Message1083{
 	MessageMsm3: rtcm3.MessageMsm3{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x43b,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x29450ed8,

--- a/rtcm3/data/1084_obj.go
+++ b/rtcm3/data/1084_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1084 = rtcm3.Message1084{
 	MessageMsm4: rtcm3.MessageMsm4{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x43c,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x29450ed8,

--- a/rtcm3/data/10852_obj.go
+++ b/rtcm3/data/10852_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message10852 = rtcm3.Message1085{
 	MessageMsm5: rtcm3.MessageMsm5{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x43d,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x19c13030,

--- a/rtcm3/data/10853_obj.go
+++ b/rtcm3/data/10853_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message10853 = rtcm3.Message1085{
 	MessageMsm5: rtcm3.MessageMsm5{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x43d,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x19c8f090,

--- a/rtcm3/data/1085_obj.go
+++ b/rtcm3/data/1085_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1085 = rtcm3.Message1085{
 	MessageMsm5: rtcm3.MessageMsm5{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x43d,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x195821a8,

--- a/rtcm3/data/1086_obj.go
+++ b/rtcm3/data/1086_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1086 = rtcm3.Message1086{
 	MessageMsm6: rtcm3.MessageMsm6{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x43e,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x29450ed8,

--- a/rtcm3/data/1087_obj.go
+++ b/rtcm3/data/1087_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1087 = rtcm3.Message1087{
 	MessageMsm7: rtcm3.MessageMsm7{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x43f,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x29450ed8,

--- a/rtcm3/data/1091_obj.go
+++ b/rtcm3/data/1091_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1091 = rtcm3.Message1091{
 	MessageMsm1: rtcm3.MessageMsm1{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x443,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x1a6055a8,

--- a/rtcm3/data/1092_obj.go
+++ b/rtcm3/data/1092_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1092 = rtcm3.Message1092{
 	MessageMsm2: rtcm3.MessageMsm2{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x444,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x1a6055a8,

--- a/rtcm3/data/1093_obj.go
+++ b/rtcm3/data/1093_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1093 = rtcm3.Message1093{
 	MessageMsm3: rtcm3.MessageMsm3{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x445,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x1a6055a8,

--- a/rtcm3/data/1094_obj.go
+++ b/rtcm3/data/1094_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1094 = rtcm3.Message1094{
 	MessageMsm4: rtcm3.MessageMsm4{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x446,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x1a6055a8,

--- a/rtcm3/data/1095_obj.go
+++ b/rtcm3/data/1095_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1095 = rtcm3.Message1095{
 	MessageMsm5: rtcm3.MessageMsm5{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x447,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x1a6055a8,

--- a/rtcm3/data/1096_obj.go
+++ b/rtcm3/data/1096_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1096 = rtcm3.Message1096{
 	MessageMsm6: rtcm3.MessageMsm6{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x448,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x1a6055a8,

--- a/rtcm3/data/1097_obj.go
+++ b/rtcm3/data/1097_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1097 = rtcm3.Message1097{
 	MessageMsm7: rtcm3.MessageMsm7{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x449,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x1a6055a8,

--- a/rtcm3/data/1111_obj.go
+++ b/rtcm3/data/1111_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1111 = rtcm3.Message1111{
 	MessageMsm1: rtcm3.MessageMsm1{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x457,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x1a6055a8,

--- a/rtcm3/data/1112_obj.go
+++ b/rtcm3/data/1112_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1112 = rtcm3.Message1112{
 	MessageMsm2: rtcm3.MessageMsm2{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x458,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x1a6055a8,

--- a/rtcm3/data/1113_obj.go
+++ b/rtcm3/data/1113_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1113 = rtcm3.Message1113{
 	MessageMsm3: rtcm3.MessageMsm3{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x459,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x1a6055a8,

--- a/rtcm3/data/1114_obj.go
+++ b/rtcm3/data/1114_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1114 = rtcm3.Message1114{
 	MessageMsm4: rtcm3.MessageMsm4{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x45a,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x1a6055a8,

--- a/rtcm3/data/1115_obj.go
+++ b/rtcm3/data/1115_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1115 = rtcm3.Message1115{
 	MessageMsm5: rtcm3.MessageMsm5{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x45b,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x1a6055a8,

--- a/rtcm3/data/1116_obj.go
+++ b/rtcm3/data/1116_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1116 = rtcm3.Message1116{
 	MessageMsm6: rtcm3.MessageMsm6{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x45c,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x1a6055a8,

--- a/rtcm3/data/1117_obj.go
+++ b/rtcm3/data/1117_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1117 = rtcm3.Message1117{
 	MessageMsm7: rtcm3.MessageMsm7{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x45d,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x1aa722a8,

--- a/rtcm3/data/1121_obj.go
+++ b/rtcm3/data/1121_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1121 = rtcm3.Message1121{
 	MessageMsm1: rtcm3.MessageMsm1{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x461,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x1a601ef8,

--- a/rtcm3/data/1122_obj.go
+++ b/rtcm3/data/1122_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1122 = rtcm3.Message1122{
 	MessageMsm2: rtcm3.MessageMsm2{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x462,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x1a601ef8,

--- a/rtcm3/data/1123_obj.go
+++ b/rtcm3/data/1123_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1123 = rtcm3.Message1123{
 	MessageMsm3: rtcm3.MessageMsm3{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x463,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x1a601ef8,

--- a/rtcm3/data/1124_obj.go
+++ b/rtcm3/data/1124_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1124 = rtcm3.Message1124{
 	MessageMsm4: rtcm3.MessageMsm4{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x464,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x1a601ef8,

--- a/rtcm3/data/1125_obj.go
+++ b/rtcm3/data/1125_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1125 = rtcm3.Message1125{
 	MessageMsm5: rtcm3.MessageMsm5{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x465,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x1a601ef8,

--- a/rtcm3/data/1126_obj.go
+++ b/rtcm3/data/1126_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1126 = rtcm3.Message1126{
 	MessageMsm6: rtcm3.MessageMsm6{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x466,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x1a601ef8,

--- a/rtcm3/data/1127_obj.go
+++ b/rtcm3/data/1127_obj.go
@@ -6,7 +6,7 @@ import (
 
 var Message1127 = rtcm3.Message1127{
 	MessageMsm7: rtcm3.MessageMsm7{
-		Header: rtcm3.MsmHeader{
+		MsmHeader: rtcm3.MsmHeader{
 			MessageNumber:          0x467,
 			ReferenceStationId:     0x0,
 			Epoch:                  0x1a601ef8,

--- a/rtcm3/glonass.go
+++ b/rtcm3/glonass.go
@@ -33,8 +33,8 @@ type GlonassObservationHeader struct {
 	SmoothingInterval  uint8
 }
 
-func (obsHeader GlonassObservationHeader) Number() uint16 {
-	return obsHeader.MessageNumber
+func (obsHeader GlonassObservationHeader) Number() int {
+	return int(obsHeader.MessageNumber)
 }
 
 func (h GlonassObservationHeader) Time() time.Time {
@@ -364,8 +364,8 @@ type Message1020 struct {
 	Reserved                  uint8
 }
 
-func (msg Message1020) Number() uint16 {
-	return msg.MessageNumber
+func (msg Message1020) Number() int {
+	return int(msg.MessageNumber)
 }
 
 func DeserializeMessage1020(data []byte) Message1020 {
@@ -468,8 +468,8 @@ type Message1230 struct {
 	L2PCodePhaseBias   int16
 }
 
-func (msg Message1230) Number() uint16 {
-	return msg.MessageNumber
+func (msg Message1230) Number() int {
+	return int(msg.MessageNumber)
 }
 
 func DeserializeMessage1230(data []byte) (msg Message1230) {

--- a/rtcm3/gps.go
+++ b/rtcm3/gps.go
@@ -23,8 +23,8 @@ type GpsObservationHeader struct {
 	SmoothingInterval  uint8
 }
 
-func (obsHeader GpsObservationHeader) Number() uint16 {
-	return obsHeader.MessageNumber
+func (obsHeader GpsObservationHeader) Number() int {
+	return int(obsHeader.MessageNumber)
 }
 
 func NewGpsObservationHeader(r *iobit.Reader) (header GpsObservationHeader) {
@@ -351,8 +351,8 @@ type Message1019 struct {
 	FitInterval   bool
 }
 
-func (msg Message1019) Number() uint16 {
-	return msg.MessageNumber
+func (msg Message1019) Number() int {
+	return int(msg.MessageNumber)
 }
 
 func DeserializeMessage1019(data []byte) Message1019 {

--- a/rtcm3/messages_test.go
+++ b/rtcm3/messages_test.go
@@ -48,7 +48,7 @@ func TestSerializeDeserialize(t *testing.T) {
 			t.Errorf("Serialization->Deserialization not equal")
 		}
 
-		if !cmp.Equal(deserializedMessage.Number(), uint16(number)) {
+		if !cmp.Equal(deserializedMessage.Number(), number) {
 			t.Errorf("MessageNumber incorrect")
 		}
 	}

--- a/rtcm3/msm.go
+++ b/rtcm3/msm.go
@@ -23,8 +23,8 @@ type MsmHeader struct {
 	CellMask               uint64
 }
 
-func (header MsmHeader) Number() uint16 {
-	return header.MessageNumber
+func (header MsmHeader) Number() int {
+	return int(header.MessageNumber)
 }
 
 func DeserializeMsmHeader(r *iobit.Reader) (header MsmHeader) {
@@ -140,10 +140,11 @@ type MessageMsm7 struct {
 	SignalData    SignalDataMsm7
 }
 
-func DeserializeMessageMsm7(r *iobit.Reader) (msg MessageMsm7) {
-	msg.MsmHeader = DeserializeMsmHeader(r)
-	msg.SatelliteData = DeserializeSatelliteDataMsm57(r, bits.OnesCount(uint(msg.MsmHeader.SatelliteMask)))
-	msg.SignalData = DeserializeSignalDataMsm7(r, bits.OnesCount(uint(msg.MsmHeader.CellMask)))
+func DeserializeMessageMsm7(data []byte) (msg MessageMsm7) {
+	r := iobit.NewReader(data)
+	msg.MsmHeader = DeserializeMsmHeader(&r)
+	msg.SatelliteData = DeserializeSatelliteDataMsm57(&r, bits.OnesCount(uint(msg.MsmHeader.SatelliteMask)))
+	msg.SignalData = DeserializeSignalDataMsm7(&r, bits.OnesCount(uint(msg.MsmHeader.CellMask)))
 	return msg
 }
 
@@ -240,10 +241,11 @@ type MessageMsm6 struct {
 	SignalData    SignalDataMsm6
 }
 
-func DeserializeMessageMsm6(r *iobit.Reader) (msg MessageMsm6) {
-	msg.MsmHeader = DeserializeMsmHeader(r)
-	msg.SatelliteData = DeserializeSatelliteDataMsm46(r, bits.OnesCount(uint(msg.MsmHeader.SatelliteMask)))
-	msg.SignalData = DeserializeSignalDataMsm6(r, bits.OnesCount(uint(msg.MsmHeader.CellMask)))
+func DeserializeMessageMsm6(data []byte) (msg MessageMsm6) {
+	r := iobit.NewReader(data)
+	msg.MsmHeader = DeserializeMsmHeader(&r)
+	msg.SatelliteData = DeserializeSatelliteDataMsm46(&r, bits.OnesCount(uint(msg.MsmHeader.SatelliteMask)))
+	msg.SignalData = DeserializeSignalDataMsm6(&r, bits.OnesCount(uint(msg.MsmHeader.CellMask)))
 	return msg
 }
 
@@ -317,10 +319,11 @@ type MessageMsm5 struct {
 	SignalData    SignalDataMsm5
 }
 
-func DeserializeMessageMsm5(r *iobit.Reader) (msg MessageMsm5) {
-	msg.MsmHeader = DeserializeMsmHeader(r)
-	msg.SatelliteData = DeserializeSatelliteDataMsm57(r, bits.OnesCount(uint(msg.MsmHeader.SatelliteMask)))
-	msg.SignalData = DeserializeSignalDataMsm5(r, bits.OnesCount(uint(msg.MsmHeader.CellMask)))
+func DeserializeMessageMsm5(data []byte) (msg MessageMsm5) {
+	r := iobit.NewReader(data)
+	msg.MsmHeader = DeserializeMsmHeader(&r)
+	msg.SatelliteData = DeserializeSatelliteDataMsm57(&r, bits.OnesCount(uint(msg.MsmHeader.SatelliteMask)))
+	msg.SignalData = DeserializeSignalDataMsm5(&r, bits.OnesCount(uint(msg.MsmHeader.CellMask)))
 	return msg
 }
 
@@ -393,10 +396,11 @@ type MessageMsm4 struct {
 	SignalData    SignalDataMsm4
 }
 
-func DeserializeMessageMsm4(r *iobit.Reader) (msg MessageMsm4) {
-	msg.MsmHeader = DeserializeMsmHeader(r)
-	msg.SatelliteData = DeserializeSatelliteDataMsm46(r, bits.OnesCount(uint(msg.MsmHeader.SatelliteMask)))
-	msg.SignalData = DeserializeSignalDataMsm4(r, bits.OnesCount(uint(msg.MsmHeader.CellMask)))
+func DeserializeMessageMsm4(data []byte) (msg MessageMsm4) {
+	r := iobit.NewReader(data)
+	msg.MsmHeader = DeserializeMsmHeader(&r)
+	msg.SatelliteData = DeserializeSatelliteDataMsm46(&r, bits.OnesCount(uint(msg.MsmHeader.SatelliteMask)))
+	msg.SignalData = DeserializeSignalDataMsm4(&r, bits.OnesCount(uint(msg.MsmHeader.CellMask)))
 	return msg
 }
 
@@ -473,10 +477,11 @@ type MessageMsm3 struct {
 	SignalData    SignalDataMsm3
 }
 
-func DeserializeMessageMsm3(r *iobit.Reader) (msg MessageMsm3) {
-	msg.MsmHeader = DeserializeMsmHeader(r)
-	msg.SatelliteData = DeserializeSatelliteDataMsm123(r, bits.OnesCount(uint(msg.MsmHeader.SatelliteMask)))
-	msg.SignalData = DeserializeSignalDataMsm3(r, bits.OnesCount(uint(msg.MsmHeader.CellMask)))
+func DeserializeMessageMsm3(data []byte) (msg MessageMsm3) {
+	r := iobit.NewReader(data)
+	msg.MsmHeader = DeserializeMsmHeader(&r)
+	msg.SatelliteData = DeserializeSatelliteDataMsm123(&r, bits.OnesCount(uint(msg.MsmHeader.SatelliteMask)))
+	msg.SignalData = DeserializeSignalDataMsm3(&r, bits.OnesCount(uint(msg.MsmHeader.CellMask)))
 	return msg
 }
 
@@ -537,10 +542,11 @@ type MessageMsm2 struct {
 	SignalData    SignalDataMsm2
 }
 
-func DeserializeMessageMsm2(r *iobit.Reader) (msg MessageMsm2) {
-	msg.MsmHeader = DeserializeMsmHeader(r)
-	msg.SatelliteData = DeserializeSatelliteDataMsm123(r, bits.OnesCount(uint(msg.MsmHeader.SatelliteMask)))
-	msg.SignalData = DeserializeSignalDataMsm2(r, bits.OnesCount(uint(msg.MsmHeader.CellMask)))
+func DeserializeMessageMsm2(data []byte) (msg MessageMsm2) {
+	r := iobit.NewReader(data)
+	msg.MsmHeader = DeserializeMsmHeader(&r)
+	msg.SatelliteData = DeserializeSatelliteDataMsm123(&r, bits.OnesCount(uint(msg.MsmHeader.SatelliteMask)))
+	msg.SignalData = DeserializeSignalDataMsm2(&r, bits.OnesCount(uint(msg.MsmHeader.CellMask)))
 	return msg
 }
 
@@ -590,10 +596,11 @@ type MessageMsm1 struct {
 	SignalData    SignalDataMsm1
 }
 
-func DeserializeMessageMsm1(r *iobit.Reader) (msg MessageMsm1) {
-	msg.MsmHeader = DeserializeMsmHeader(r)
-	msg.SatelliteData = DeserializeSatelliteDataMsm123(r, bits.OnesCount(uint(msg.MsmHeader.SatelliteMask)))
-	msg.SignalData = DeserializeSignalDataMsm1(r, bits.OnesCount(uint(msg.MsmHeader.CellMask)))
+func DeserializeMessageMsm1(data []byte) (msg MessageMsm1) {
+	r := iobit.NewReader(data)
+	msg.MsmHeader = DeserializeMsmHeader(&r)
+	msg.SatelliteData = DeserializeSatelliteDataMsm123(&r, bits.OnesCount(uint(msg.MsmHeader.SatelliteMask)))
+	msg.SignalData = DeserializeSignalDataMsm1(&r, bits.OnesCount(uint(msg.MsmHeader.CellMask)))
 	return msg
 }
 
@@ -632,7 +639,7 @@ func DeserializeMessage1071(data []byte) Message1071 {
 }
 
 func (msg Message1071) Time() time.Time {
-	return GpsTime(msg.Header.Epoch)
+	return GpsTime(msg.MsmHeader.Epoch)
 }
 
 // GPS MSM2
@@ -647,7 +654,7 @@ func DeserializeMessage1072(data []byte) Message1072 {
 }
 
 func (msg Message1072) Time() time.Time {
-	return GpsTime(msg.Header.Epoch)
+	return GpsTime(msg.MsmHeader.Epoch)
 }
 
 // GPS MSM3
@@ -662,7 +669,7 @@ func DeserializeMessage1073(data []byte) Message1073 {
 }
 
 func (msg Message1073) Time() time.Time {
-	return GpsTime(msg.Header.Epoch)
+	return GpsTime(msg.MsmHeader.Epoch)
 }
 
 // GPS MSM4
@@ -677,7 +684,7 @@ func DeserializeMessage1074(data []byte) Message1074 {
 }
 
 func (msg Message1074) Time() time.Time {
-	return GpsTime(msg.Header.Epoch)
+	return GpsTime(msg.MsmHeader.Epoch)
 }
 
 // GPS MSM5
@@ -692,7 +699,7 @@ func DeserializeMessage1075(data []byte) Message1075 {
 }
 
 func (msg Message1075) Time() time.Time {
-	return GpsTime(msg.Header.Epoch)
+	return GpsTime(msg.MsmHeader.Epoch)
 }
 
 // GPS MSM6
@@ -707,7 +714,7 @@ func DeserializeMessage1076(data []byte) Message1076 {
 }
 
 func (msg Message1076) Time() time.Time {
-	return GpsTime(msg.Header.Epoch)
+	return GpsTime(msg.MsmHeader.Epoch)
 }
 
 // GPS MSM7
@@ -722,7 +729,7 @@ func DeserializeMessage1077(data []byte) Message1077 {
 }
 
 func (msg Message1077) Time() time.Time {
-	return GpsTime(msg.Header.Epoch)
+	return GpsTime(msg.MsmHeader.Epoch)
 }
 
 // GLONASS MSM1
@@ -737,7 +744,7 @@ func DeserializeMessage1081(data []byte) Message1081 {
 }
 
 func (msg Message1081) Time() time.Time {
-	return GlonassTime(msg.Header.Epoch)
+	return GlonassTime(msg.MsmHeader.Epoch)
 }
 
 // GLONASS MSM2
@@ -752,7 +759,7 @@ func DeserializeMessage1082(data []byte) Message1082 {
 }
 
 func (msg Message1082) Time() time.Time {
-	return GlonassTime(msg.Header.Epoch)
+	return GlonassTime(msg.MsmHeader.Epoch)
 }
 
 // GLONASS MSM3
@@ -767,7 +774,7 @@ func DeserializeMessage1083(data []byte) Message1083 {
 }
 
 func (msg Message1083) Time() time.Time {
-	return GlonassTime(msg.Header.Epoch)
+	return GlonassTime(msg.MsmHeader.Epoch)
 }
 
 // GLONASS MSM4
@@ -782,7 +789,7 @@ func DeserializeMessage1084(data []byte) Message1084 {
 }
 
 func (msg Message1084) Time() time.Time {
-	return GlonassTime(msg.Header.Epoch)
+	return GlonassTime(msg.MsmHeader.Epoch)
 }
 
 // GLONASS MSM5
@@ -797,7 +804,7 @@ func DeserializeMessage1085(data []byte) Message1085 {
 }
 
 func (msg Message1085) Time() time.Time {
-	return GlonassTime(msg.Header.Epoch)
+	return GlonassTime(msg.MsmHeader.Epoch)
 }
 
 // GLONASS MSM6
@@ -812,7 +819,7 @@ func DeserializeMessage1086(data []byte) Message1086 {
 }
 
 func (msg Message1086) Time() time.Time {
-	return GlonassTime(msg.Header.Epoch)
+	return GlonassTime(msg.MsmHeader.Epoch)
 }
 
 // GLONASS MSM7
@@ -827,7 +834,7 @@ func DeserializeMessage1087(data []byte) Message1087 {
 }
 
 func (msg Message1087) Time() time.Time {
-	return GlonassTime(msg.Header.Epoch)
+	return GlonassTime(msg.MsmHeader.Epoch)
 }
 
 // Galileo MSM1
@@ -842,7 +849,7 @@ func DeserializeMessage1091(data []byte) Message1091 {
 }
 
 func (msg Message1091) Time() time.Time {
-	return GpsTime(msg.Header.Epoch)
+	return GpsTime(msg.MsmHeader.Epoch)
 }
 
 // Galileo MSM2
@@ -857,7 +864,7 @@ func DeserializeMessage1092(data []byte) Message1092 {
 }
 
 func (msg Message1092) Time() time.Time {
-	return GpsTime(msg.Header.Epoch)
+	return GpsTime(msg.MsmHeader.Epoch)
 }
 
 // Galileo MSM3
@@ -872,7 +879,7 @@ func DeserializeMessage1093(data []byte) Message1093 {
 }
 
 func (msg Message1093) Time() time.Time {
-	return GpsTime(msg.Header.Epoch)
+	return GpsTime(msg.MsmHeader.Epoch)
 }
 
 // Galileo MSM4
@@ -887,7 +894,7 @@ func DeserializeMessage1094(data []byte) Message1094 {
 }
 
 func (msg Message1094) Time() time.Time {
-	return GpsTime(msg.Header.Epoch)
+	return GpsTime(msg.MsmHeader.Epoch)
 }
 
 // Galileo MSM5
@@ -902,7 +909,7 @@ func DeserializeMessage1095(data []byte) Message1095 {
 }
 
 func (msg Message1095) Time() time.Time {
-	return GpsTime(msg.Header.Epoch)
+	return GpsTime(msg.MsmHeader.Epoch)
 }
 
 // Galileo MSM6
@@ -917,7 +924,7 @@ func DeserializeMessage1096(data []byte) Message1096 {
 }
 
 func (msg Message1096) Time() time.Time {
-	return GpsTime(msg.Header.Epoch)
+	return GpsTime(msg.MsmHeader.Epoch)
 }
 
 // Galileo MSM7
@@ -932,7 +939,7 @@ func DeserializeMessage1097(data []byte) Message1097 {
 }
 
 func (msg Message1097) Time() time.Time {
-	return GpsTime(msg.Header.Epoch)
+	return GpsTime(msg.MsmHeader.Epoch)
 }
 
 // SBAS MSM1
@@ -947,7 +954,7 @@ func DeserializeMessage1101(data []byte) Message1101 {
 }
 
 func (msg Message1101) Time() time.Time {
-	return GpsTime(msg.Header.Epoch)
+	return GpsTime(msg.MsmHeader.Epoch)
 }
 
 // SBAS MSM2
@@ -962,7 +969,7 @@ func DeserializeMessage1102(data []byte) Message1102 {
 }
 
 func (msg Message1102) Time() time.Time {
-	return GpsTime(msg.Header.Epoch)
+	return GpsTime(msg.MsmHeader.Epoch)
 }
 
 // SBAS MSM3
@@ -977,7 +984,7 @@ func DeserializeMessage1103(data []byte) Message1103 {
 }
 
 func (msg Message1103) Time() time.Time {
-	return GpsTime(msg.Header.Epoch)
+	return GpsTime(msg.MsmHeader.Epoch)
 }
 
 // SBAS MSM4
@@ -992,7 +999,7 @@ func DeserializeMessage1104(data []byte) Message1104 {
 }
 
 func (msg Message1104) Time() time.Time {
-	return GpsTime(msg.Header.Epoch)
+	return GpsTime(msg.MsmHeader.Epoch)
 }
 
 // SBAS MSM5
@@ -1007,7 +1014,7 @@ func DeserializeMessage1105(data []byte) Message1105 {
 }
 
 func (msg Message1105) Time() time.Time {
-	return GpsTime(msg.Header.Epoch)
+	return GpsTime(msg.MsmHeader.Epoch)
 }
 
 // SBAS MSM6
@@ -1022,7 +1029,7 @@ func DeserializeMessage1106(data []byte) Message1106 {
 }
 
 func (msg Message1106) Time() time.Time {
-	return GpsTime(msg.Header.Epoch)
+	return GpsTime(msg.MsmHeader.Epoch)
 }
 
 // SBAS MSM7
@@ -1037,7 +1044,7 @@ func DeserializeMessage1107(data []byte) Message1107 {
 }
 
 func (msg Message1107) Time() time.Time {
-	return GpsTime(msg.Header.Epoch)
+	return GpsTime(msg.MsmHeader.Epoch)
 }
 
 // QZSS MSM1
@@ -1052,7 +1059,7 @@ func DeserializeMessage1111(data []byte) Message1111 {
 }
 
 func (msg Message1111) Time() time.Time {
-	return GpsTime(msg.Header.Epoch)
+	return GpsTime(msg.MsmHeader.Epoch)
 }
 
 // QZSS MSM2
@@ -1067,7 +1074,7 @@ func DeserializeMessage1112(data []byte) Message1112 {
 }
 
 func (msg Message1112) Time() time.Time {
-	return GpsTime(msg.Header.Epoch)
+	return GpsTime(msg.MsmHeader.Epoch)
 }
 
 // QZSS MSM3
@@ -1082,7 +1089,7 @@ func DeserializeMessage1113(data []byte) Message1113 {
 }
 
 func (msg Message1113) Time() time.Time {
-	return GpsTime(msg.Header.Epoch)
+	return GpsTime(msg.MsmHeader.Epoch)
 }
 
 // QZSS MSM4
@@ -1097,7 +1104,7 @@ func DeserializeMessage1114(data []byte) Message1114 {
 }
 
 func (msg Message1114) Time() time.Time {
-	return GpsTime(msg.Header.Epoch)
+	return GpsTime(msg.MsmHeader.Epoch)
 }
 
 // QZSS MSM5
@@ -1112,7 +1119,7 @@ func DeserializeMessage1115(data []byte) Message1115 {
 }
 
 func (msg Message1115) Time() time.Time {
-	return GpsTime(msg.Header.Epoch)
+	return GpsTime(msg.MsmHeader.Epoch)
 }
 
 // QZSS MSM6
@@ -1127,7 +1134,7 @@ func DeserializeMessage1116(data []byte) Message1116 {
 }
 
 func (msg Message1116) Time() time.Time {
-	return GpsTime(msg.Header.Epoch)
+	return GpsTime(msg.MsmHeader.Epoch)
 }
 
 // QZSS MSM7
@@ -1142,7 +1149,7 @@ func DeserializeMessage1117(data []byte) Message1117 {
 }
 
 func (msg Message1117) Time() time.Time {
-	return GpsTime(msg.Header.Epoch)
+	return GpsTime(msg.MsmHeader.Epoch)
 }
 
 // BeiDou MSM1
@@ -1157,7 +1164,7 @@ func DeserializeMessage1121(data []byte) Message1121 {
 }
 
 func (msg Message1121) Time() time.Time {
-	return GpsTime(msg.Header.Epoch).Add(14 * time.Second)
+	return GpsTime(msg.MsmHeader.Epoch).Add(14 * time.Second)
 }
 
 // BeiDou MSM2
@@ -1172,7 +1179,7 @@ func DeserializeMessage1122(data []byte) Message1122 {
 }
 
 func (msg Message1122) Time() time.Time {
-	return GpsTime(msg.Header.Epoch).Add(14 * time.Second)
+	return GpsTime(msg.MsmHeader.Epoch).Add(14 * time.Second)
 }
 
 // BeiDou MSM3
@@ -1187,7 +1194,7 @@ func DeserializeMessage1123(data []byte) Message1123 {
 }
 
 func (msg Message1123) Time() time.Time {
-	return GpsTime(msg.Header.Epoch).Add(14 * time.Second)
+	return GpsTime(msg.MsmHeader.Epoch).Add(14 * time.Second)
 }
 
 // BeiDou MSM4
@@ -1202,7 +1209,7 @@ func DeserializeMessage1124(data []byte) Message1124 {
 }
 
 func (msg Message1124) Time() time.Time {
-	return GpsTime(msg.Header.Epoch).Add(14 * time.Second)
+	return GpsTime(msg.MsmHeader.Epoch).Add(14 * time.Second)
 }
 
 // BeiDou MSM5
@@ -1217,7 +1224,7 @@ func DeserializeMessage1125(data []byte) Message1125 {
 }
 
 func (msg Message1125) Time() time.Time {
-	return GpsTime(msg.Header.Epoch).Add(14 * time.Second)
+	return GpsTime(msg.MsmHeader.Epoch).Add(14 * time.Second)
 }
 
 // BeiDou MSM6
@@ -1232,7 +1239,7 @@ func DeserializeMessage1126(data []byte) Message1126 {
 }
 
 func (msg Message1126) Time() time.Time {
-	return GpsTime(msg.Header.Epoch).Add(14 * time.Second)
+	return GpsTime(msg.MsmHeader.Epoch).Add(14 * time.Second)
 }
 
 // BeiDou MSM7
@@ -1247,5 +1254,5 @@ func DeserializeMessage1127(data []byte) Message1127 {
 }
 
 func (msg Message1127) Time() time.Time {
-	return GpsTime(msg.Header.Epoch).Add(14 * time.Second)
+	return GpsTime(msg.MsmHeader.Epoch).Add(14 * time.Second)
 }

--- a/rtcm3/residual.go
+++ b/rtcm3/residual.go
@@ -37,8 +37,8 @@ type Message1030 struct {
 	SatelliteData      []ResidualSatelliteData
 }
 
-func (msg Message1030) Number() uint16 {
-	return msg.MessageNumber
+func (msg Message1030) Number() int {
+	return int(msg.MessageNumber)
 }
 
 func DeserializeMessage1030(data []byte) (msg Message1030) {
@@ -69,8 +69,8 @@ type Message1031 struct {
 	SatelliteData      []ResidualSatelliteData
 }
 
-func (msg Message1031) Number() uint16 {
-	return msg.MessageNumber
+func (msg Message1031) Number() int {
+	return int(msg.MessageNumber)
 }
 
 func DeserializeMessage1031(data []byte) (msg Message1031) {
@@ -101,8 +101,8 @@ type Message1032 struct {
 	ArpEcefZ                      int64
 }
 
-func (msg Message1032) Number() uint16 {
-	return msg.MessageNumber
+func (msg Message1032) Number() int {
+	return int(msg.MessageNumber)
 }
 
 func DeserializeMessage1032(data []byte) Message1032 {

--- a/rtcm3/rtcm3.go
+++ b/rtcm3/rtcm3.go
@@ -11,7 +11,7 @@ import (
 
 type Message interface {
 	Serialize() []byte
-	Number() uint16
+	Number() int
 }
 
 func DeserializeMessage(payload []byte) (msg Message) {
@@ -157,8 +157,8 @@ func (msg MessageUnknown) Serialize() []byte {
 	return msg.Payload
 }
 
-func (msg MessageUnknown) Number() (msgNumber uint16) {
-	return binary.BigEndian.Uint16(msg.Payload[0:4]) >> 4
+func (msg MessageUnknown) Number() (msgNumber int) {
+	return int(binary.BigEndian.Uint16(msg.Payload[0:4]) >> 4)
 }
 
 type Observable interface {

--- a/rtcm3/system.go
+++ b/rtcm3/system.go
@@ -22,8 +22,8 @@ type Message1013 struct {
 	Messages           []MessageAnnouncement
 }
 
-func (msg Message1013) Number() uint16 {
-	return msg.MessageNumber
+func (msg Message1013) Number() int {
+	return int(msg.MessageNumber)
 }
 
 func DeserializeMessage1013(data []byte) (msg Message1013) {
@@ -76,8 +76,8 @@ type Message1029 struct {
 	CodeUnits          string
 }
 
-func (msg Message1029) Number() uint16 {
-	return msg.MessageNumber
+func (msg Message1029) Number() int {
+	return int(msg.MessageNumber)
 }
 
 func DeserializeMessage1029(data []byte) (msg Message1029) {


### PR DESCRIPTION
Looks like a big change, but basically all I have done is make the MSM1-7 messages inherit from MsmHeader, instead of each having a Header attribute of type MsmHeader. I did this so each of the MSM1-7 types didn't need to implement a Number method (this is now implemented by MsmHeader and inherited by each MSM).

I also changed the Number method for the Message interface to return an int instead of a uint16, as I'm always converting to int when using it anyway.